### PR TITLE
Fix cell payload overflow

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -351,7 +351,7 @@ func (db *Database) openPage(page int) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	p, err := newBtree(buf, page == 1)
+	p, err := newBtree(buf, page == 1, db.header.PageSize)
 	if err == nil {
 		db.btreeCache.set(page, p)
 	}


### PR DESCRIPTION
Cell payload overflow calculations did not implement the complex logic from the spec to determine the number of bytes stored in page.  This PR implements those calculations.
